### PR TITLE
Add oneof option to fix oneof record definitions

### DIFF
--- a/src/gpb_compile.erl
+++ b/src/gpb_compile.erl
@@ -122,6 +122,7 @@
                boolean_opt(descriptor) |
                boolean_opt(maps) |
                boolean_opt(msgs_as_maps) |
+               boolean_opt(oneof_as_tuples) |
                boolean_opt(mapfields_as_maps) |
                boolean_opt(defs_as_maps) |
                {maps_unset_optional, omitted | present_undefined} |
@@ -2130,6 +2131,9 @@ opt_specs() ->
      {"maps_key_type", {atom, binary}, maps_key_type,
       "atom | binary\n"
       "       Specifies the key type for maps.\n"},
+     {"oneof-as-tuples", undefined, oneof_as_tuples, "\n"
+      "        Specifies if oneof fields are tuples or not.\n"
+      "        Otherwise, they will be the value directly. Default is true.\n"},
      {"msgs-as-maps", undefined, msgs_as_maps, "\n"
       "        Specifies that messages should be maps.\n"
       "        Otherwise, they will be records.\n"},

--- a/src/gpb_gen_types.erl
+++ b/src/gpb_gen_types.erl
@@ -452,7 +452,7 @@ oneof_type_strs(MsgName,
                   _ ->
                       case gpb_lib:get_oneof_as_tuples_by_opts(Opts) of
                           true -> fun(Tag, TypeStr) -> ?f("{~p, ~s}", [Tag, TypeStr]) end;
-                          false -> fun(Tag, TypeStr) -> TypeStr end
+                          false -> fun(_Tag, TypeStr) -> TypeStr end
                       end
               end,
     ElemPath = [MsgName, FName],

--- a/src/gpb_gen_types.erl
+++ b/src/gpb_gen_types.erl
@@ -450,7 +450,10 @@ oneof_type_strs(MsgName,
                   #maps{oneof=flat} ->
                       fun(_Tag, TypeStr) -> TypeStr end;
                   _ ->
-                      fun(Tag, TypeStr) -> ?f("{~p, ~s}", [Tag, TypeStr]) end
+                      case gpb_lib:get_oneof_as_tuples_by_opts(Opts) of
+                          true -> fun(Tag, TypeStr) -> ?f("{~p, ~s}", [Tag, TypeStr]) end;
+                          false -> fun(Tag, TypeStr) -> TypeStr end
+                      end
               end,
     ElemPath = [MsgName, FName],
     case gpb_gen_translators:has_type_spec_translation(ElemPath, AnRes) of

--- a/src/gpb_lib.erl
+++ b/src/gpb_lib.erl
@@ -75,6 +75,7 @@
 
 -export([get_2tuples_or_maps_for_maptype_fields_by_opts/1]).
 -export([get_records_or_maps_by_opts/1]).
+-export([get_oneof_as_tuples_by_opts/1]).
 -export([get_mapping_and_unset_by_opts/1]).
 -export([get_strings_as_binaries_by_opts/1]).
 -export([get_type_specs_by_opts/1]).
@@ -600,6 +601,10 @@ get_records_or_maps_by_opts(Opts) ->
         false -> records;
         true  -> maps
     end.
+
+get_oneof_as_tuples_by_opts(Opts) ->
+    Default = true,
+    proplists:get_value(oneof_as_tuples, Opts, Default).
 
 get_mapping_and_unset_by_opts(Opts) ->
     case get_records_or_maps_by_opts(Opts) of


### PR DESCRIPTION
- I add a oneof_as_tuples option to cleanup the record definitions.
- Tested this by generating the files using this.
- Later, I also plan to fix this codec as well to do the matching based on the types rather than the field names.