### PR TITLE
Add custom option to rename enum fields

### DIFF
--- a/src/gpb_compile.erl
+++ b/src/gpb_compile.erl
@@ -189,7 +189,8 @@
                     {service_fqname, name_change()} |
                     {rpc_name, name_change()} |
                     {msg_typename, name_change()} |
-                    {enum_typename, name_change()}.
+                    {enum_typename, name_change()} |
+                    {enum_fieldname, name_change()}.
 
 -type name_change() :: {prefix, string() | atom()} |
                        {suffix, string() | atom()} |
@@ -2087,6 +2088,7 @@ opt_specs() ->
       "         rpc_name       The RPC name.\n"
       "         msg_typename   Erlang type names for messages and groups.\n"
       "         enum_typename  Erlang type names for enums.\n"
+      "         enum_fieldname Erlang field names for enums.\n"
       "       How:\n"
       "          prefix=Prefix        Prepend the Prefix.\n"
       "          suffix=Suffix        Append the Suffix.\n"
@@ -2275,6 +2277,7 @@ opt_rename_what(S) ->
         "rpc_name:"++S2       -> {rpc_name, S2};
         "msg_typename:"++S2   -> {msg_typename, S2};
         "enum_typename:"++S2  -> {enum_typename, S2};
+        "enum_fieldname:"++S2 -> {enum_fieldname, S2};
         _ -> throw({badopt, "Invalid thing to rename: "++S})
     end.
 

--- a/src/gpb_names.erl
+++ b/src/gpb_names.erl
@@ -358,7 +358,7 @@ mk_renamings(RenameOps, Defs, Opts) ->
     MsgTypeRenamings = msg_type_renamings(MsgRenamings, GroupRenamings,
                                           RenameOps),
     EnumTypeRenamings = enum_type_renamings(EnumRenamings, RenameOps),
-    EnumFieldRenamings = enum_field_renamings(PkgByProto, PkgRenamings, Defs, RenameOps),
+    EnumFieldRenamings = enum_field_renamings(PkgByProto, Defs, RenameOps),
     case check_no_dups(MostRenamings, RpcRenamings) of
         ok ->
             InversePkgRenamings = invert_renaming(PkgRenamings),
@@ -486,7 +486,7 @@ enum_renamings(PkgByProto, PkgRenamings, Defs, RenameOps) ->
          end
          || {{enum_containment, Proto}, EnumNames} <- Defs])).
 
-enum_field_renamings(PkgByProto, _PkgRenamings, Defs, RenameOps) ->
+enum_field_renamings(PkgByProto, Defs, RenameOps) ->
     dict:from_list(
       lists:append(
         [begin
@@ -677,7 +677,7 @@ do_rename(RF, Defs) ->
          ({{group,Name}, Fields}) ->
               {{group, RF(group, Name)}, rename_fields(RF, Fields, Defs)};
          ({{enum, Name}, Enumerators}) ->
-              {{enum, RF(enum, Name)}, rename_enumerators(RF, Enumerators)};
+              {{enum, RF(enum, Name)}, rename_enum_fields(RF, Enumerators)};
          ({{extensions,Name}, Exts}) ->
               {{extensions, RF(msg, Name)}, Exts};
          ({{service,Name}, Rpcs}) ->
@@ -723,7 +723,7 @@ rename_fields(RF, Fields, Defs) ->
       end,
       Fields).
 
-rename_enumerators(RF, Enumerators) ->
+rename_enum_fields(RF, Enumerators) ->
     lists:map(
         fun({FieldName, Value}) ->
             {RF(enum_fields, FieldName), Value}

--- a/src/gpb_names.erl
+++ b/src/gpb_names.erl
@@ -282,7 +282,8 @@ mk_rename_op(service_fqname, How) -> mk_service_rename_op(How);
 mk_rename_op(service_name, How) -> mk_service_rename_op(How);
 mk_rename_op(rpc_name, How) -> mk_rpc_rename_op(How);
 mk_rename_op(msg_typename, How) -> mk_msgtype_rename_op(How);
-mk_rename_op(enum_typename, How) -> mk_enumtype_rename_op(How).
+mk_rename_op(enum_typename, How) -> mk_enumtype_rename_op(How);
+mk_rename_op(enum_fieldname, How) -> mk_enumfield_rename_op(How).
 
 mk_pkg_rename_op(PrimOp) ->
     fun(Name, _Proto) -> do_prim_op(PrimOp, Name) end.
@@ -309,6 +310,9 @@ mk_msgtype_rename_op(PrimOp) ->
     fun(Name, _Proto) -> do_prim_op(PrimOp, Name) end.
 
 mk_enumtype_rename_op(PrimOp) ->
+    fun(Name, _Proto) -> do_prim_op(PrimOp, Name) end.
+
+mk_enumfield_rename_op(PrimOp) ->
     fun(Name, _Proto) -> do_prim_op(PrimOp, Name) end.
 
 do_prim_op({prefix, Prefix}, Name) ->
@@ -354,6 +358,7 @@ mk_renamings(RenameOps, Defs, Opts) ->
     MsgTypeRenamings = msg_type_renamings(MsgRenamings, GroupRenamings,
                                           RenameOps),
     EnumTypeRenamings = enum_type_renamings(EnumRenamings, RenameOps),
+    EnumFieldRenamings = enum_field_renamings(PkgByProto, PkgRenamings, Defs, RenameOps),
     case check_no_dups(MostRenamings, RpcRenamings) of
         ok ->
             InversePkgRenamings = invert_renaming(PkgRenamings),
@@ -370,7 +375,8 @@ mk_renamings(RenameOps, Defs, Opts) ->
                             {services, ServiceRenamings},
                             {rpcs, RpcRenamings},
                             {msg_types, MsgTypeRenamings},
-                            {enum_types, EnumTypeRenamings}],
+                            {enum_types, EnumTypeRenamings},
+                            {enum_fields, EnumFieldRenamings}],
                             %% Reverse renamings:
                            [{inverse_pkgs, InversePkgRenamings}
                             || UsePackages],
@@ -389,6 +395,7 @@ mk_renamer(Renamings) ->
     EnumRenamings = key1fetch(enums, Renamings),
     ServiceRenamings = key1fetch(services, Renamings),
     RpcRenamings = key1fetch(rpcs, Renamings),
+    EnumFieldRenamings = key1fetch(enum_fields, Renamings),
     fun(package, Name) ->
             if PkgRenamings /= undefined ->
                     dict_fetch(Name, PkgRenamings);
@@ -405,6 +412,8 @@ mk_renamer(Renamings) ->
             dict_fetch(Name, EnumRenamings);
        (service, Name) ->
             dict_fetch(Name, ServiceRenamings);
+       (enum_fields, Name) ->
+            dict_fetch(Name, EnumFieldRenamings);
        ({rpc, ServiceName}, RpcName) ->
             dict_fetch({ServiceName, RpcName}, RpcRenamings)
     end.
@@ -476,6 +485,18 @@ enum_renamings(PkgByProto, PkgRenamings, Defs, RenameOps) ->
               || FqName <- EnumNames]
          end
          || {{enum_containment, Proto}, EnumNames} <- Defs])).
+
+enum_field_renamings(PkgByProto, _PkgRenamings, Defs, RenameOps) ->
+    dict:from_list(
+      lists:append(
+        [begin
+             [begin
+              NewFieldName = run_ops(enum_fieldname, FieldName, Proto, RenameOps),
+              {FieldName, NewFieldName}
+              end
+              || {FieldName, _Value} <- EnumFields]
+         end
+         || {{enum, Proto}, EnumFields} <- Defs])).
 
 calc_enum_name_renaming(FqName, Pkg, PkgRenamings, Proto, RenameOps) ->
     Name = drop_prefix(Pkg, FqName),
@@ -656,7 +677,7 @@ do_rename(RF, Defs) ->
          ({{group,Name}, Fields}) ->
               {{group, RF(group, Name)}, rename_fields(RF, Fields, Defs)};
          ({{enum, Name}, Enumerators}) ->
-              {{enum, RF(enum, Name)}, Enumerators};
+              {{enum, RF(enum, Name)}, rename_enumerators(RF, Enumerators)};
          ({{extensions,Name}, Exts}) ->
               {{extensions, RF(msg, Name)}, Exts};
          ({{service,Name}, Rpcs}) ->
@@ -701,6 +722,12 @@ rename_fields(RF, Fields, Defs) ->
               F
       end,
       Fields).
+
+rename_enumerators(RF, Enumerators) ->
+    lists:map(
+        fun({FieldName, Value}) ->
+            {RF(enum_fields, FieldName), Value}
+        end, Enumerators).
 
 rename_rpcs(RF, ServiceName, RPCs) ->
     lists:map(


### PR DESCRIPTION
- gpb has options to automatically modify message names, message type names, enum types.
- But nothing for enum fields exists.
- This diff basically adds an option to modify these fields. They can be converted to snakecase, lowercase, prefixed or suffixed.
- We'll need this for protobuf changes.
- I'll push this upstream shortly.