### PR TITLE
Add support for custom proto field option - ebin

### DIFF
--- a/src/gpb_gen_types.erl
+++ b/src/gpb_gen_types.erl
@@ -206,7 +206,8 @@ format_hfields(MsgName, Indent, Fields, AnRes, Opts, Defs) ->
                                                 gpb_lib:proto3_type_default(
                                                   Type,
                                                   Defs,
-                                                  Opts),
+                                                  Opts,
+                                                  FOpts),
                                             ?f(" = ~p", [Default]);
                                         _ -> ""
                                     end;
@@ -400,7 +401,7 @@ flatten_oneof_ftcs([]) ->
     [].
 
 field_type_str(MsgName,
-               #?gpb_field{name=FName, type=Type, occurrence=Occurrence},
+               #?gpb_field{name=FName, type=Type, occurrence=Occurrence, opts = FieldOpts},
                Defs, AnRes, Opts) ->
     OrUndefined = case gpb_lib:get_mapping_and_unset_by_opts(Opts) of
                       records ->
@@ -423,7 +424,7 @@ field_type_str(MsgName,
                 defaulty -> TypeStr ++ OrUndefined
             end;
         false ->
-            TypeStr = type_to_typestr_2(Type, Defs, AnRes, Opts),
+            TypeStr = type_to_typestr_2(Type, Defs, AnRes, Opts, FieldOpts),
             case Occurrence of
                 required ->
                     TypeStr ++ OrUndefined;
@@ -492,6 +493,16 @@ oneof_type_strs(MsgName,
              || #?gpb_field{name=Name, type=Type} <- OFields]
                 ++ OrUndefinedElems
     end.
+
+
+type_to_typestr_2(int64, Defs, AnRes, Opts, FieldOpts) ->
+    case proplists:get_bool(ebin, FieldOpts) of
+        false -> type_to_typestr_2(int64, Defs, AnRes, Opts);
+        true  -> "binary()"
+    end;
+type_to_typestr_2(Type, Defs, AnRes, Opts, _FieldOpts) ->
+    type_to_typestr_2(Type, Defs, AnRes, Opts).
+
 
 type_to_typestr_2(sint32, _Defs, _AnRes, _Opts)   -> "integer()";
 type_to_typestr_2(sint64, _Defs, _AnRes, _Opts)   -> "integer()";

--- a/src/gpb_lib.erl
+++ b/src/gpb_lib.erl
@@ -97,6 +97,7 @@
 -export([current_otp_release/0]).
 -export([proto2_type_default/3]).
 -export([proto3_type_default/3]).
+-export([proto3_type_default/4]).
 -export([get_maps_key_type_by_opts/1]).
 -export([json_by_opts/1]).
 -export([json_object_format_by_opts/1]).
@@ -755,6 +756,15 @@ proto2_type_default(Type, Defs, Opts) ->
 
 proto3_type_default(Type, Defs, Opts) ->
     type_default(Type, Defs, Opts, fun gpb:proto3_type_default/2).
+
+proto3_type_default(Type, Defs, Opts, Fopts) ->
+    type_default(Type, Defs, Opts, Fopts, fun gpb:proto3_type_default/2).
+
+type_default(Type, Defs, Opts, Fopts, GetTypeDefault) ->
+    IsEbin = proplists:get_bool(ebin, Fopts),
+    if IsEbin -> GetTypeDefault(bytes, Defs);
+       true -> type_default(Type, Defs, Opts, GetTypeDefault)
+    end.
 
 type_default(Type, Defs, Opts, GetTypeDefault) ->
     if Type == string ->


### PR DESCRIPTION
- add support for a custom field option called 'ebin'.
- ebin when set to true on a field - will generate records with type as binary and default value empty binary.
- we'll be using this option with the uid field.
- this will help us getting rid of translating uids to binaries.
- because currently uids are int64 in protobuf and binaries in erlang code.

Example:
```proto3
msg foo{
    int64 a = 1 [ebin = true];
    int64 b = 2;
}
```
records generated from gpb will be:
```erlang
#foo{
    a = <<>> :: binary()
    b = 0 :: integer()
}
```

when encoding these records:
we can send in #foo{a = <<"123">>, b = 456}  - value of field a will be converted to integer from binary and then encoded on the wire.. since it will be smaller then.
so, clients will be able to decrypt this to integers only..
